### PR TITLE
mavlink_main.cpp - add fix for Cygwin (Windows)

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1026,7 +1026,7 @@ Mavlink::find_broadcast_address()
 	struct ifconf ifconf;
 	int ret;
 
-#if defined(__APPLE__) && defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__) || defined(__CYGWIN__)
 	// On Mac, we can't determine the required buffer
 	// size in advance, so we just use what tends to work.
 	ifconf.ifc_len = 1024;


### PR DESCRIPTION
fix for issue https://github.com/PX4/Firmware/issues/11030 - "getting required buffer size failed" on jmavsim simulation on Windows 10

**Problem solved**
After this little addition jmavsim can be steered OK via mavros on Windows (Cygwin) platform 

**Additional context**
There are some other places use `#if defined(__APPLE__) && defined(__MACH__)` in the code. Perhaps, they also need to be revised for Cygwin, but first flight test passes ok with this only small addition.
Little "Flight test" I used to pass, after tested mavlink heartbeat:
`rostopic pub -r 5 /mavros/setpoint_position/local geometry_msgs/PoseStamped "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
pose:
  position:
    x: 0.0
    y: 0.0
    z: 10.0
  orientation:
    x: 0.0
    y: 0.0
    z: 0.0
    w: 0.0"`
`rosservice call /mavros/set_mode "base_mode: 0 custom_mode: 'OFFBOARD'"`
`rosservice call /mavros/cmd/arming "value: true"`